### PR TITLE
feat(grammarV2): enhance the browser back action in grammar page.

### DIFF
--- a/app/api/completion/route.ts
+++ b/app/api/completion/route.ts
@@ -1,5 +1,5 @@
-export const dynamic = 'force-dynamic' // defaults to auto
-export const runtime = 'edge';
+export const dynamic = "force-dynamic"; // defaults to auto
+export const runtime = "edge";
 import { ChatType } from "@/app/utils/const";
 import { generateGemini } from "@/app/actions/gemeni";
 import { NextApiResponse } from "next";

--- a/app/grammarV2/atom.ts
+++ b/app/grammarV2/atom.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai";
 import type { TGrammarDataset, TGrammarV2 } from "../data/grammarV2";
+import { GrammarSTAGE } from "../types";
 
 const initDataasetAtom = atom<TGrammarDataset>("v1");
 export const datasetAtom = atom<TGrammarDataset, [TGrammarDataset], any>(
@@ -24,6 +25,15 @@ export const grammarFavAtom = atom<TGrammarFav, [TGrammarFav], any>(
   (get) => get(initGrammarFavAtom),
   (_, set, update) => {
     set(initGrammarFavAtom, update);
+    return update;
+  }
+);
+
+const initPrevStageAtom = atom<GrammarSTAGE[]>([]);
+export const prevStageAtom = atom<GrammarSTAGE[], [GrammarSTAGE[]], any>(
+  (get) => get(initPrevStageAtom),
+  (_, set, update) => {
+    set(initPrevStageAtom, update);
     return update;
   }
 );

--- a/app/grammarV2/stageResult.tsx
+++ b/app/grammarV2/stageResult.tsx
@@ -60,7 +60,7 @@ export default function StageResult({
       >
         New Quiz
       </Button>
-      {wrongList.length && (
+      {wrongList.length > 0 && (
         <p className={cn(style.title_color, "text-sm mb-2")}>
           Wrong questions(click to check detail):
         </p>

--- a/app/grammarV2/stageReview.tsx
+++ b/app/grammarV2/stageReview.tsx
@@ -25,10 +25,7 @@ interface StageReviewProps {
   className?: string;
   grammarList: TGrammarV2[];
   index: number;
-  handleChangGrammarSTAGE: (
-    stage: GrammarSTAGE,
-    level?: GrammarLevelTypeV2
-  ) => void;
+  handleChangStage: (stage: GrammarSTAGE, level?: GrammarLevelTypeV2) => void;
   updateGrammarIndex: (index: number) => void;
 }
 
@@ -41,7 +38,7 @@ export default function StageReview({
   className,
   grammarList,
   index,
-  handleChangGrammarSTAGE,
+  handleChangStage,
   updateGrammarIndex
 }: StageReviewProps) {
   const [grammarFav, setGrammarFav] = useAtom(grammarFavAtom);
@@ -87,7 +84,9 @@ export default function StageReview({
             obj[key] = res.result;
           }
           setGrammarFav(obj);
-          toast.success("Updated!", { duration: 2000 });
+          toast.success(isDelete ? "Favorite removed!" : "Favorite added!", {
+            duration: 2000
+          });
           return res;
         }
       }
@@ -158,7 +157,7 @@ export default function StageReview({
               <Button
                 className={cn("bg-[#e36f23] text-white text-sm")}
                 size="sm"
-                onPress={() => handleChangGrammarSTAGE(GrammarSTAGE.TESTING)}
+                onPress={() => handleChangStage(GrammarSTAGE.TESTING)}
               >
                 Start
               </Button>

--- a/app/utils/eventBus.ts
+++ b/app/utils/eventBus.ts
@@ -1,0 +1,45 @@
+"use client";
+
+class EventBus {
+  private static instance: EventBus;
+  private events: { [key: string]: Function[] };
+
+  constructor() {
+    this.events = {};
+  }
+
+  static getInstance(): EventBus {
+    if (!EventBus.instance) {
+      EventBus.instance = new EventBus();
+    }
+
+    return EventBus.instance;
+  }
+
+  on(event: string, callback: Function): void {
+    if (!this.events[event]) {
+      this.events[event] = [];
+    }
+
+    this.events[event].push(callback);
+  }
+
+  off(event: string, callback: Function): void {
+    if (!this.events[event]) {
+      return;
+    }
+
+    this.events[event] = this.events[event].filter((cb) => cb !== callback);
+  }
+
+  emit(event: string, data?: any): void {
+    if (!this.events[event]) {
+      return;
+    }
+
+    this.events[event].forEach((callback) => callback(data));
+  }
+}
+
+const eventBus = EventBus.getInstance();
+export default eventBus;

--- a/app/utils/history.ts
+++ b/app/utils/history.ts
@@ -1,0 +1,24 @@
+"use client";
+
+export function historyBack() {
+  if (typeof window !== "undefined") {
+    window.history.back();
+  }
+}
+
+/**
+ * Pushes a new hash to the browser's history.
+ *
+ * @param hash - The hash to be added to the URL.
+ */
+export function historyPushHash(hash: string) {
+  if (typeof window !== "undefined") {
+    const queryString = window.location.search;
+
+    let s = "";
+    if (queryString) {
+      s += `?${queryString}`;
+    }
+    window.history.pushState(null, "", `${queryString}#${hash}`);
+  }
+}


### PR DESCRIPTION
The GrammarV2 page has four stages and some modals. If the user triggers a browser action (such as swiping back on Android), it will navigate the entire page backward, which may confuse the user.

The cases like below(all action is browser back):

- Stage start jump to stage review

expect: back to the start stage

- Wrong question modal opened

expect: close the modal